### PR TITLE
Fixed missing parens in configurations

### DIFF
--- a/test/test-fwk.js
+++ b/test/test-fwk.js
@@ -5,9 +5,9 @@ import config from '../config.json'
 export {config}
 
 const url = process.env.URL ||
-  process.env.PORT
+  (process.env.PORT
     ? `${config.host}:${process.env.PORT}`
-    : `${config.host}:${config.port}${config.basePath}`;
+    : `${config.host}:${config.port}${config.basePath}`);
 export const server = supertest.agent(url)
 
 export function resource(resourceName, description) {


### PR DESCRIPTION
For what it seems, the intended behavior is, if the URL is specified as an environment variable, then it should use it as the url of the server, if not, it uses the host defined in the config file, and tries to set the port, if specified in an environment variable, or else, the one used in the config file.

As it is, it checks if it has any of the URL or PORT and then sets using always the config file.
